### PR TITLE
add ability to create a new project

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -346,6 +346,7 @@ fn new_project(name: &str, path: &str) {
     }
     projects.push(project.clone());
     save_projects(&projects);
+    open_project(&project.name, OpenAction::OpenInTerminal);
 }
 
 fn show_home_interface(prompt: &str) {


### PR DESCRIPTION
user can add a new project by either running `tpm` and selecting `new project` or by running
```shell
tpm new "project name"
```